### PR TITLE
修复部分超链接，更改部分README的编码格式为UTF-8

### DIFF
--- a/NyanConsole/NyanConsole_readme.md
+++ b/NyanConsole/NyanConsole_readme.md
@@ -1,2 +1,2 @@
-## Cmd_MEMZ±¸×¢
-´Ë³ÌÐòÉÐÎ´¿ªÔ´£¬²¿·ÖMIDI¿ØÖÆÀ´×ÔÓÚgithub¿ªÔ´´úÂë¡£
+## Cmd_MEMZå¤‡æ³¨
+æ­¤ç¨‹åºå°šæœªå¼€æºï¼Œéƒ¨åˆ†MIDIæŽ§åˆ¶æ¥è‡ªäºŽgithubå¼€æºä»£ç ã€‚

--- a/multimedia/multimedia_readme.md
+++ b/multimedia/multimedia_readme.md
@@ -1,8 +1,8 @@
 # 多媒体文件下载地址
 ## 由于github的上传下载速度过慢，作者将把这些文件放在weiyun。
-> 1.data(Buttercup片段 大小157.19KB)地址：https://share.weiyun.com/aaj2qb8L  
-> 2.data(360MEMZ片头鬼畜音频 大小791.54KB)地址：https://share.weiyun.com/kli2ZkS3  
-> 360MEMZ.wmv(360MEMZ的鬼畜视频 大小5.44MB)地址：https://share.weiyun.com/owQbPxz3  
-> pic1.bmp(360MEMZ壁纸 大小3MB)地址：https://share.weiyun.com/wqScqUW1  
+> [1.data(Buttercup片段 大小157.19KB)](https://share.weiyun.com/aaj2qb8L)  
+> [2.data(360MEMZ片头鬼畜音频 大小791.54KB)](https://share.weiyun.com/kli2ZkS3)  
+> [360MEMZ.wmv(360MEMZ的鬼畜视频 大小5.44MB)](https://share.weiyun.com/owQbPxz3)
+> [pic1.bmp(360MEMZ壁纸 大小3MB)](https://share.weiyun.com/wqScqUW1)
   
 **确保程序运行时这些文件在可执行文件同目录下**  

--- a/stopworking/stopworking_readme.md
+++ b/stopworking/stopworking_readme.md
@@ -1,2 +1,2 @@
-## StopWorking备注
-此项目已开源至*https://github.com/CnAoKip/StopWorking*，请确保程序运行时此程序在可执行文件同目录下
+## StopWorking澶囨敞
+姝ら」鐩凡寮�婧愯嚦https://github.com/CnAoKip/StopWorking  锛岃纭繚绋嬪簭杩愯鏃舵绋嬪簭鍦ㄥ彲鎵ц鏂囦欢鍚岀洰褰曚笅

--- a/taskbar/taskbar_readme.md
+++ b/taskbar/taskbar_readme.md
@@ -4,4 +4,4 @@
 ```Shell
   taskbar.exe <FileName>
 ```
-其中FileName为指定的剧本名，剧本格式参照*https://www.bilibili.com/video/BV1uT4y1j7at* 的视频。
+其中FileName为指定的剧本名，剧本格式参照*https://www.bilibili.com/video/BV1uT4y1j7at*  的视频。


### PR DESCRIPTION
> 修复部分超链接在Github上无法正确识别的问题
> 更改部分README的编码格式为UTF-8以解决文件在Linux下的乱码问题